### PR TITLE
Api versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Run the application:
 uvicorn --reload app.main:app
 ```
 
-Go to <http://127.0.0.1:8000/docs> to browse the API.
+Go to <http://127.0.0.1:8000/api/v1/docs> to browse the API.
 
 Using `uvicorn` with the `--reload` parameter will automatically restart the application when a file changes.
 Note that the logging configuration assumes that the application is run with gunicorn.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Run the application:
 uvicorn --reload app.main:app
 ```
 
-Go to <http://127.0.0.1:8000/api/v1/docs> to browse the API.
+Go to <http://127.0.0.1:8000/api/v1/docs> and <http://127.0.0.1:8000/api/v2/docs> to browse the API depending on the version.
 
 Using `uvicorn` with the `--reload` parameter will automatically restart the application when a file changes.
 Note that the logging configuration assumes that the application is run with gunicorn.

--- a/alembic/versions/06fd850a57c0_rename_apn_token_to_device_token.py
+++ b/alembic/versions/06fd850a57c0_rename_apn_token_to_device_token.py
@@ -1,0 +1,31 @@
+"""Rename apn_token to device_token
+
+Revision ID: 06fd850a57c0
+Revises: 0881dca000d8
+Create Date: 2021-03-27 13:32:58.393608
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "06fd850a57c0"
+down_revision = "0881dca000d8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "users",
+        "_apn_tokens",
+        new_column_name="_device_tokens",
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "users",
+        "_device_tokens",
+        new_column_name="_apn_tokens",
+    )

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -6,7 +6,7 @@ from jwt import PyJWTError, ExpiredSignatureError
 from .. import crud, models, utils
 from ..database import SessionLocal
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/v1/login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="login")
 
 
 def get_db():

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -9,6 +9,7 @@ router = APIRouter()
 
 
 @router.get("/", response_model=List[schemas.User])
+@version(2)
 def read_users(
     db: Session = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_admin_user),
@@ -19,6 +20,7 @@ def read_users(
 
 
 @router.patch("/{user_id}", response_model=schemas.User)
+@version(2)
 def update_user(
     user_id: int,
     updated_info: schemas.UserUpdate,
@@ -36,6 +38,7 @@ def update_user(
 
 
 @router.delete("/{user_id}", response_model=schemas.User)
+@version(2)
 def delete_user(
     user_id: int,
     db: Session = Depends(deps.get_db),

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, Response, HTTPException, status
+from fastapi_versioning import version
 from sqlalchemy.orm import Session
 from typing import List
 from . import deps
@@ -49,7 +50,17 @@ def delete_user(
     crud.delete_user(db, user)
 
 
+@router.get("/user/profile", response_model=schemas.UserV1)
+@version(1)
+def read_current_user_profile_v1(
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    """Return the current user profile"""
+    return current_user.to_v1()
+
+
 @router.get("/user/profile", response_model=schemas.User)
+@version(2)
 def read_current_user_profile(
     current_user: models.User = Depends(deps.get_current_user),
 ):
@@ -58,19 +69,42 @@ def read_current_user_profile(
 
 
 @router.post(
-    "/user/apn-token", response_model=schemas.User, status_code=status.HTTP_201_CREATED
+    "/user/apn-token",
+    response_model=schemas.UserV1,
+    status_code=status.HTTP_201_CREATED,
 )
+@version(1)
 def create_current_user_apn_token(
     response: Response,
     apn_token: schemas.ApnToken,
     db: Session = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_user),
 ):
-    """Create or update an apn token for the current user"""
-    if apn_token.apn_token in current_user.apn_tokens:
+    """Create or update an apn token for the current user (v1 only - deprecated)"""
+    if apn_token.apn_token in current_user.device_tokens:
+        response.status_code = status.HTTP_200_OK
+        return current_user.to_v1()
+    user = crud.create_user_device_token(db, apn_token.apn_token, current_user)
+    return user.to_v1()
+
+
+@router.post(
+    "/user/device-token",
+    response_model=schemas.User,
+    status_code=status.HTTP_201_CREATED,
+)
+@version(2)
+def create_current_user_device_token(
+    response: Response,
+    device_token: schemas.DeviceToken,
+    db: Session = Depends(deps.get_db),
+    current_user: models.User = Depends(deps.get_current_user),
+):
+    """Create or update a device token for the current user"""
+    if device_token.device_token in current_user.device_tokens:
         response.status_code = status.HTTP_200_OK
         return current_user
-    return crud.create_user_apn_token(db, apn_token.apn_token, current_user)
+    return crud.create_user_device_token(db, device_token.device_token, current_user)
 
 
 @router.get("/user/services", response_model=List[schemas.UserService])

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -88,6 +88,15 @@ def create_current_user_apn_token(
     return user.to_v1()
 
 
+@router.post("/user/apn-token", include_in_schema=False)
+@version(2)
+def create_current_user_apn_token_deprecated():
+    """Override v1 endpoint"""
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+    )
+
+
 @router.post(
     "/user/device-token",
     response_model=schemas.User,

--- a/app/crud.py
+++ b/app/crud.py
@@ -30,10 +30,10 @@ def create_user(db: Session, username: str):
     return db_user
 
 
-def create_user_apn_token(
-    db: Session, apn_token: str, user: models.User
+def create_user_device_token(
+    db: Session, device_token: str, user: models.User
 ) -> models.User:
-    user.add_apn_token(apn_token)
+    user.add_device_token(device_token)
     db.commit()
     db.refresh(user)
     return user
@@ -56,10 +56,10 @@ def delete_user(db: Session, user: models.User):
     db.commit()
 
 
-def remove_user_apn_token(
-    db: Session, user: models.User, apn_token: str
+def remove_user_device_token(
+    db: Session, user: models.User, device_token: str
 ) -> models.User:
-    user.remove_apn_token(apn_token)
+    user.remove_device_token(device_token)
     db.commit()
     db.refresh(user)
     return user

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -10,10 +10,22 @@ class ApnToken(BaseModel):
     apn_token: str
 
 
-class User(BaseModel):
+class DeviceToken(BaseModel):
+    device_token: str
+
+
+class UserV1(BaseModel):
     id: int
     username: str
     apn_tokens: List[str]
+    is_active: bool
+    is_admin: bool
+
+
+class User(BaseModel):
+    id: int
+    username: str
+    device_tokens: List[str]
     is_active: bool
     is_admin: bool
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -107,7 +107,7 @@ async def send_push_to_ios(
             logger.info(
                 f"Device token no longer active. Delete {apn} for user {user.username}"
             )
-            crud.remove_user_apn_token(db, user, apn)
+            crud.remove_user_device_token(db, user, apn)
         return False
     logger.info(f"Notification sent to user {user.username}")
     return True
@@ -136,13 +136,13 @@ async def send_notification(db: Session, notification: models.Notification) -> N
     tasks = [
         send_push_to_ios(
             client,
-            apn_token,
+            device_token,
             user_notification.to_apn_payload(),
             db,
             user_notification.user,
         )
         for user_notification in notification.users_notification
-        for apn_token in user_notification.user.apn_tokens
+        for device_token in user_notification.user.device_tokens
     ]
     await gather_with_concurrency(NB_PARALLEL_PUSH, *tasks, return_exceptions=True)
     await client.aclose()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ cffi==1.14.3
 click==7.1.2
 cryptography==3.2.1
 fastapi==0.61.2
+fastapi-versioning==0.8.0
 gunicorn==20.0.4
 h11==0.11.0
 h2==4.0.0

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ postgres_requires = ["psycopg2"]
 requirements = [
     "alembic==1.5.7",
     "fastapi==0.61.2",
+    "fastapi-versioning",
     "python-multipart==0.0.5",
     "h11==0.11.0",
     "h2==4.0.0",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ requirements = [
     "uvicorn[standard]",
     "gunicorn==20.0.4",
     "sentry-sdk==0.19.3",
-    "Faker==5.4.0",
 ]
 tests_requires = [
     "pytest",
@@ -34,6 +33,7 @@ tests_requires = [
     "pytest-factoryboy",
     "requests",
     "respx",
+    "Faker",
 ]
 
 setuptools.setup(

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -77,6 +77,15 @@ def test_read_current_user_profile_inactive(
     assert response.json() == {"detail": "Inactive user"}
 
 
+def test_create_current_user_apn_token_v2_not_found(client: TestClient, db, user):
+    response = client.post(
+        "/api/v2/users/user/apn-token",
+        headers=user_authorization_headers(user.username),
+        json={"apn-token": "foo"},
+    )
+    assert response.status_code == 404
+
+
 @pytest.mark.parametrize(
     "endpoint, token_name",
     [

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -293,7 +293,7 @@ def test_read_users(client: TestClient, user_factory):
     user3 = user_factory()
     admin = user_factory(is_admin=True)
     response = client.get(
-        "/api/v1/users/", headers=user_authorization_headers(admin.username)
+        "/api/v2/users/", headers=user_authorization_headers(admin.username)
     )
     assert response.status_code == 200
     users = [
@@ -328,7 +328,7 @@ def test_update_user(
     admin = user_factory(is_admin=True)
     assert not user1.is_admin
     response = client.patch(
-        f"/api/v1/users/{user1.id}",
+        f"/api/v2/users/{user1.id}",
         headers=user_authorization_headers(admin.username),
         json=updated_info,
     )
@@ -344,7 +344,7 @@ def test_update_user(
 
 def test_update_user_invalid_id(client: TestClient, admin_token_headers):
     response = client.patch(
-        "/api/v1/users/1234",
+        "/api/v2/users/1234",
         headers=admin_token_headers,
         json={},
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,3 +73,8 @@ def admin_token_headers(user_factory):
     admin = user_factory(is_admin=True)
     token = create_access_token(admin.username)
     return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(params=["v1", "v2"])
+def api_version(request):
+    return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ environ["TEAM_ID"] = "6F44JJ9SDF"
 environ["ADMIN_USERS"] = "admin1,admin2"
 environ["NB_PARALLEL_PUSH"] = "2"
 
-from app.main import app  # noqa E402
+from app.main import original_app, app  # noqa E402
 from app.database import Base, engine  # noqa E402
 from app.api import deps  # noqa E402
 from app.utils import create_access_token  # noqa E402
@@ -50,7 +50,7 @@ def db(connection) -> Generator:
     factories.UserFactory._meta.sqlalchemy_session = session
     factories.ServiceFactory._meta.sqlalchemy_session = session
     factories.NotificationFactory._meta.sqlalchemy_session = session
-    app.dependency_overrides[deps.get_db] = lambda: session
+    original_app.dependency_overrides[deps.get_db] = lambda: session
     yield session
     session.close()
     transaction.rollback()

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -215,8 +215,8 @@ def test_update_user_notifications(db, user, service_factory):
         (["one", "two"], "one", ["two"]),
     ],
 )
-def test_remove_user_apn_token(db, user_factory, initial_tokens, removed, expected):
-    user = user_factory(apn_tokens=initial_tokens)
-    assert user.apn_tokens == initial_tokens
-    crud.remove_user_apn_token(db, user, removed)
-    assert user.apn_tokens == expected
+def test_remove_user_device_token(db, user_factory, initial_tokens, removed, expected):
+    user = user_factory(device_tokens=initial_tokens)
+    assert user.device_tokens == initial_tokens
+    crud.remove_user_device_token(db, user, removed)
+    assert user.device_tokens == expected

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,31 +10,31 @@ def test_user(db: Session, user_factory) -> None:
     assert user.is_active
     assert not user.is_admin
     assert not hasattr(user, "token")
-    assert user.apn_tokens == []
-    assert user._apn_tokens == ""
+    assert user.device_tokens == []
+    assert user._device_tokens == ""
 
 
-def test_user_add_apn_token(db: Session, user) -> None:
-    apn_token1 = "my-token"
-    user.add_apn_token(apn_token1)
-    assert user.apn_tokens == [apn_token1]
-    assert user._apn_tokens == apn_token1
-    apn_token2 = "another-token"
-    user.add_apn_token(apn_token2)
-    assert user.apn_tokens == [apn_token1, apn_token2]
-    assert user._apn_tokens == f"{apn_token1};{apn_token2}"
+def test_user_add_device_token(db: Session, user) -> None:
+    device_token1 = "my-token"
+    user.add_device_token(device_token1)
+    assert user.device_tokens == [device_token1]
+    assert user._device_tokens == device_token1
+    device_token2 = "another-token"
+    user.add_device_token(device_token2)
+    assert user.device_tokens == [device_token1, device_token2]
+    assert user._device_tokens == f"{device_token1};{device_token2}"
     # Adding an existing token doesn't change anything
-    user.add_apn_token(apn_token1)
-    assert user.apn_tokens == [apn_token1, apn_token2]
+    user.add_device_token(device_token1)
+    assert user.device_tokens == [device_token1, device_token2]
 
 
-def test_user_remove_apn_token(db: Session, user_factory) -> None:
-    user = user_factory(apn_tokens=["first-token", "second-token"])
+def test_user_remove_device_token(db: Session, user_factory) -> None:
+    user = user_factory(device_tokens=["first-token", "second-token"])
     # Removing a non existing token doesn't change anything
-    user.remove_apn_token("foo")
-    assert user.apn_tokens == ["first-token", "second-token"]
-    user.remove_apn_token("first-token")
-    assert user.apn_tokens == ["second-token"]
+    user.remove_device_token("foo")
+    assert user.device_tokens == ["first-token", "second-token"]
+    user.remove_device_token("first-token")
+    assert user.device_tokens == ["second-token"]
 
 
 def test_user_subscribe_service(db: Session, user, service_factory):

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -2,6 +2,6 @@ from fastapi.testclient import TestClient
 
 
 def test_health_check(client: TestClient):
-    response = client.get("/-/health")
+    response = client.get("/api/v1/-/health")
     assert response.status_code == 200
     assert response.text == "OK"

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,7 +1,7 @@
 from fastapi.testclient import TestClient
 
 
-def test_health_check(client: TestClient):
-    response = client.get("/api/v1/-/health")
+def test_health_check(client: TestClient, api_version):
+    response = client.get(f"/api/{api_version}/-/health")
     assert response.status_code == 200
     assert response.text == "OK"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,42 +96,42 @@ async def test_send_push_to_ios_success(db, user, apn_payload):
 )
 async def test_send_push_to_ios_error(db, user_factory, apn_payload, side_effect):
     # No exception raised in case of error
-    apn_token = "my-token"
-    user = user_factory(apn_tokens=[apn_token])
-    assert user.apn_tokens == [apn_token]
+    device_token = "my-token"
+    user = user_factory(device_tokens=[device_token])
+    assert user.device_tokens == [device_token]
     request = respx.post(
-        f"https://api.development.push.apple.com/3/device/{apn_token}",
+        f"https://api.development.push.apple.com/3/device/{device_token}",
     )
     request.side_effect = side_effect
     async with httpx.AsyncClient(http2=True) as client:
         notification_sent = await utils.send_push_to_ios(
-            client, apn_token, apn_payload, db, user
+            client, device_token, apn_payload, db, user
         )
     assert request.called
     assert not notification_sent
     db.refresh(user)
-    assert user.apn_tokens == [apn_token]
+    assert user.device_tokens == [device_token]
 
 
 @respx.mock
 @pytest.mark.asyncio
 async def test_send_push_to_ios_410(db, user_factory, apn_payload):
-    apn_token = "my-token"
-    user = user_factory(apn_tokens=[apn_token])
-    assert user.apn_tokens == [apn_token]
+    device_token = "my-token"
+    user = user_factory(device_tokens=[device_token])
+    assert user.device_tokens == [device_token]
     request = respx.post(
-        f"https://api.development.push.apple.com/3/device/{apn_token}",
+        f"https://api.development.push.apple.com/3/device/{device_token}",
     )
     request.side_effect = httpx.Response(410)
     async with httpx.AsyncClient(http2=True) as client:
         notification_sent = await utils.send_push_to_ios(
-            client, apn_token, apn_payload, db, user
+            client, device_token, apn_payload, db, user
         )
     assert request.called
     assert not notification_sent
     db.refresh(user)
     # No longer active token deleted
-    assert user.apn_tokens == []
+    assert user.device_tokens == []
 
 
 @pytest.mark.asyncio
@@ -139,9 +139,9 @@ async def test_send_notification(db, user_factory, notification_factory, mocker)
     mock_send_push_to_ios = mocker.patch("app.utils.send_push_to_ios")
     notification1 = notification_factory()
     notification2 = notification_factory()
-    user1 = user_factory(apn_tokens=["user1-apn1", "user1-apn2"])
-    user2 = user_factory(apn_tokens=["user2-apn1"])
-    user_factory(apn_tokens=["user3-apn1"])
+    user1 = user_factory(device_tokens=["user1-apn1", "user1-apn2"])
+    user2 = user_factory(device_tokens=["user2-apn1"])
+    user_factory(device_tokens=["user3-apn1"])
     user1.notifications.append(notification1)
     user1.notifications.append(notification2)
     user2.notifications.append(notification1)


### PR DESCRIPTION
Rename apn_token to device_token

Keep compatibility with v1 api for:
- `GET /api/v1/users/user/profile`
- `POST /api/v1/users/user/apn-token`

New v2 endpoint:
- `POST /api/v2/users/user/device-token` (replace apn-token)

Remove read_users delete and update user from v1 api (admin only endpoints, not used by mobile client)

Breaking change:
- `/-/health` endpoint moved to `/api/<version>/-/health` (prometheus monitoring will have to be updated)

