### PR TITLE
Add limit to read_current_user_notifications

### DIFF
--- a/app/api/users.py
+++ b/app/api/users.py
@@ -141,10 +141,12 @@ def update_current_user_services(
 
 @router.get("/user/notifications", response_model=List[schemas.UserNotification])
 def read_current_user_notifications(
+    limit: int = 50,
+    db: Session = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_user),
 ):
-    """Read the current user's notifications"""
-    return crud.get_user_notifications(current_user)
+    """Return the current user's notifications in descending order (limited to 50 by default)"""
+    return crud.get_user_notifications(db, current_user, limit)
 
 
 @router.patch("/user/notifications", status_code=status.HTTP_204_NO_CONTENT)

--- a/app/api/users.py
+++ b/app/api/users.py
@@ -142,11 +142,15 @@ def update_current_user_services(
 @router.get("/user/notifications", response_model=List[schemas.UserNotification])
 def read_current_user_notifications(
     limit: int = 50,
+    sort: schemas.SortOrder = schemas.SortOrder.asc,
     db: Session = Depends(deps.get_db),
     current_user: models.User = Depends(deps.get_current_user),
 ):
-    """Return the current user's notifications in descending order (limited to 50 by default)"""
-    return crud.get_user_notifications(db, current_user, limit)
+    """Return the current user's notifications (limited to 50 by default)
+
+    Notifications are sorted in ascending order by default
+    """
+    return crud.get_user_notifications(db, current_user, limit=limit, sort=sort)
 
 
 @router.patch("/user/notifications", status_code=status.HTTP_204_NO_CONTENT)

--- a/app/crud.py
+++ b/app/crud.py
@@ -140,12 +140,17 @@ def create_service_notification(
 
 
 def get_user_notifications(
-    db: Session, user: models.User, limit: int = 0
+    db: Session,
+    user: models.User,
+    limit: int = 0,
+    sort: schemas.SortOrder = schemas.SortOrder.desc,
 ) -> List[schemas.UserNotification]:
     """Return the latest user's notifications sorted by timestamp
 
     If limit is 0, all notifications are returned
     Otherwise, only the number requested
+    The newest notifications are always returned. Sorting by ascending order
+    will just reverse that list.
     """
     query = (
         db.query(models.UserNotification)
@@ -159,7 +164,11 @@ def get_user_notifications(
         query = query.limit(limit)
     else:
         query = query.all()
-    return [un.to_user_notification() for un in query]
+    notifications = [un.to_user_notification() for un in query]
+    # Sorting in ascending order is mostly for backward compatibility
+    if sort == schemas.SortOrder.asc:
+        notifications.reverse()
+    return notifications
 
 
 def update_user_notifications(

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,7 +1,7 @@
-from operator import attrgetter
 import datetime
 import uuid
 from fastapi.logger import logger
+from sqlalchemy import desc
 from sqlalchemy.orm import Session
 from typing import List
 from . import models, schemas
@@ -139,10 +139,27 @@ def create_service_notification(
     return db_notification
 
 
-def get_user_notifications(user: models.User) -> List[schemas.UserNotification]:
-    """Return all user's notifications sorted by timestamp"""
-    user_notifications = [un.to_user_notification() for un in user.user_notifications]
-    return sorted(user_notifications, key=attrgetter("timestamp"))[-50:]
+def get_user_notifications(
+    db: Session, user: models.User, limit: int = 0
+) -> List[schemas.UserNotification]:
+    """Return the latest user's notifications sorted by timestamp
+
+    If limit is 0, all notifications are returned
+    Otherwise, only the number requested
+    """
+    query = (
+        db.query(models.UserNotification)
+        .filter(
+            models.UserNotification.user_id == user.id,
+        )
+        .join(models.Notification)
+        .order_by(desc(models.Notification.timestamp))
+    )
+    if limit > 0:
+        query = query.limit(limit)
+    else:
+        query = query.all()
+    return [un.to_user_notification() for un in query]
 
 
 def update_user_notifications(

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -6,6 +6,11 @@ from typing import List, Optional
 from pydantic import BaseModel
 
 
+class SortOrder(str, Enum):
+    asc = "asc"
+    desc = "desc"
+
+
 class ApnToken(BaseModel):
     apn_token: str
 

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -222,8 +222,12 @@ def test_update_current_user_services(
     assert db_user.services == sorted([service1, service3], key=lambda s: s.category)
 
 
+@pytest.mark.parametrize(
+    "sort",
+    [None, "asc", "desc"],
+)
 def test_read_current_user_notifications(
-    client: TestClient, db, user, notification_factory, api_version
+    client: TestClient, db, user, notification_factory, api_version, sort
 ):
     notification1 = notification_factory()
     notification2 = notification_factory()
@@ -232,21 +236,17 @@ def test_read_current_user_notifications(
     user.notifications.append(notification1)
     user.notifications.append(notification2)
     db.commit()
+    params = {}
+    if sort is not None:
+        params = {"sort": sort}
     response = client.get(
         f"/api/{api_version}/users/user/notifications",
+        params=params,
         headers=user_authorization_headers(user.username),
     )
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": notification2.id,
-            "is_read": False,
-            "service_id": str(notification2.service_id),
-            "subtitle": notification2.subtitle,
-            "timestamp": notification2.timestamp.isoformat(),
-            "title": notification2.title,
-            "url": notification2.url,
-        },
+    # By default the notifications are expected in ascending order (for backward compatibility)
+    expected_response = [
         {
             "id": notification1.id,
             "is_read": False,
@@ -256,7 +256,19 @@ def test_read_current_user_notifications(
             "title": notification1.title,
             "url": notification1.url,
         },
+        {
+            "id": notification2.id,
+            "is_read": False,
+            "service_id": str(notification2.service_id),
+            "subtitle": notification2.subtitle,
+            "timestamp": notification2.timestamp.isoformat(),
+            "title": notification2.title,
+            "url": notification2.url,
+        },
     ]
+    if sort == "desc":
+        expected_response.reverse()
+    assert response.json() == expected_response
 
 
 def test_update_current_user_notifications(

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -239,15 +239,6 @@ def test_read_current_user_notifications(
     assert response.status_code == 200
     assert response.json() == [
         {
-            "id": notification1.id,
-            "is_read": False,
-            "service_id": str(notification1.service_id),
-            "subtitle": notification1.subtitle,
-            "timestamp": notification1.timestamp.isoformat(),
-            "title": notification1.title,
-            "url": notification1.url,
-        },
-        {
             "id": notification2.id,
             "is_read": False,
             "service_id": str(notification2.service_id),
@@ -255,6 +246,15 @@ def test_read_current_user_notifications(
             "timestamp": notification2.timestamp.isoformat(),
             "title": notification2.title,
             "url": notification2.url,
+        },
+        {
+            "id": notification1.id,
+            "is_read": False,
+            "service_id": str(notification1.service_id),
+            "subtitle": notification1.subtitle,
+            "timestamp": notification1.timestamp.isoformat(),
+            "title": notification1.title,
+            "url": notification1.url,
         },
     ]
 


### PR DESCRIPTION
Add limit and sort query parameters to read_current_user_notifications

- limit default to 50
- limit can be changed by passing the limit=nb query parameter
- if the limit is <= 0, all notifications are returned
- the notifications are returned in ascending order (oldest first) by default for backward compatibility
- order can be changed by passing sort=desc as query parameter