### PR TITLE
Only delete google token on 404

### DIFF
--- a/app/firebase.py
+++ b/app/firebase.py
@@ -58,7 +58,8 @@ async def send_push(
     except httpx.HTTPStatusError as exc:
         logger.warning(f"{exc}")
         logger.warning(response.json())
-        if response.status_code in (400, 404):
+        # See https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode
+        if response.status_code == 404:
             logger.info(
                 f"Device token invalid or no longer active. Delete {device_token} for user {user.username}"
             )


### PR DESCRIPTION
According to https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode
404: App instance was unregistered from FCM.
     This usually means that the token used
     is no longer valid and a new one must be used.

400 means INVALID_ARGUMENT. It could be Invalid registration but it could be something else.
Token shouldn't be deleted in this case.