### PR TITLE
Do not send notifications to users not active or not logged in

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,5 +12,5 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitlab-ci.maxiv.yml
+++ b/.gitlab-ci.maxiv.yml
@@ -38,11 +38,11 @@ variables:
   HELM_SET_TEST_image_tag: "__from_env_var:REGISTRY_IMAGE_TAG"
   GITLAB_ENVIRONMENT_NAME: notify
 
-test-python38:
+test-python310:
   stage: test
   tags:
     - kubernetes
-  image: harbor.maxiv.lu.se/dockerhub/library/python:3.8
+  image: harbor.maxiv.lu.se/dockerhub/library/python:3.10
   before_script:
     - pip install -e .[tests]
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,9 +5,9 @@ include:
   - remote: 'https://gitlab.esss.lu.se/ics-infrastructure/gitlab-ci-yml/raw/master/Docker.gitlab-ci.yml'
 
 
-test-python38:
+test-python310:
   stage: test
-  image: python:3.8
+  image: python:3.10
   before_script:
     - pip install -e .[tests]
   script:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
@@ -8,11 +8,11 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.982
     hooks:
       - id: mypy
         additional_dependencies:
           - 'pydantic'
           - 'PyJWT'
         exclude: (tests/)
-        language_version: "3.8"
+        language_version: "3.10"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-FROM python:3.8-slim as base
+FROM python:3.10-slim as base
 
 # Install Python dependencies in an intermediate image
 # as some requires a compiler (psycopg2)
 FROM base as builder
 
 # Install dependencies required to compile some Python packages
-# Taken from https://github.com/docker-library/python/blob/master/3.8/buster/slim/Dockerfile
+# Taken from https://github.com/docker-library/python/blob/master/3.10/slim-bullseye/Dockerfile
 # For psycopg2: libpq-dev
 RUN apt-get update \
   && apt-get install -yq --no-install-recommends \
   dpkg-dev \
   gcc \
+  gnupg dirmngr \
   libbluetooth-dev \
   libbz2-dev \
   libc6-dev \

--- a/alembic/versions/43f8a46a10f4_add_login_token_expire_date.py
+++ b/alembic/versions/43f8a46a10f4_add_login_token_expire_date.py
@@ -1,0 +1,35 @@
+"""Add login_token_expire_date
+
+Revision ID: 43f8a46a10f4
+Revises: 06fd850a57c0
+Create Date: 2022-10-16 07:42:13.437968
+
+"""
+from datetime import datetime, timedelta
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "43f8a46a10f4"
+down_revision = "06fd850a57c0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "users", sa.Column("login_token_expire_date", sa.DateTime(), nullable=True)
+    )
+    # login_token_expire_date is only updated when the user requests a new token.
+    # To avoid having to reset all tokens, we set the default value to the current date + 30 days
+    # when running this migration. This ensures users will continue to receive notifications with
+    # their current login token.
+    expire = datetime.utcnow() + timedelta(days=30)
+    users = sa.sql.table("users", sa.sql.column("login_token_expire_date"))
+    op.execute(users.update().values(login_token_expire_date=expire))
+    op.alter_column("users", "login_token_expire_date", nullable=False)
+
+
+def downgrade():
+    op.drop_column("users", "login_token_expire_date")

--- a/app/crud.py
+++ b/app/crud.py
@@ -52,6 +52,18 @@ def update_user(
     return user
 
 
+def update_user_login_token_expire_date(
+    db: Session, user: models.User, expire_date: datetime.datetime
+) -> models.User:
+    logger.info(
+        f"Update login_token_expire_date to {expire_date} for user {user.username}"
+    )
+    user.login_token_expire_date = expire_date
+    db.commit()
+    db.refresh(user)
+    return user
+
+
 def delete_user(db: Session, user: models.User):
     db.delete(user)
     db.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -75,6 +75,7 @@ class User(Base):
     _device_tokens = Column(String, default="")
     is_active = Column(Boolean, default=True, nullable=False)
     is_admin = Column(Boolean, default=False, nullable=False)
+    login_token_expire_date = Column(DateTime, default=datetime.utcnow, nullable=False)
 
     services = relationship(
         "Service",
@@ -115,6 +116,10 @@ class User(Base):
     @property
     def android_tokens(self):
         return [token for token in self.device_tokens if len(token) > 64]
+
+    @property
+    def is_logged_in(self):
+        return datetime.utcnow() < self.login_token_expire_date
 
     def add_device_token(self, value: str):
         if value in self.device_tokens:

--- a/app/utils.py
+++ b/app/utils.py
@@ -81,6 +81,8 @@ async def send_notification(db: Session, notification: models.Notification) -> N
     android_client = httpx.AsyncClient(headers=android_headers)
     for user_notification in notification.users_notification:
         user = user_notification.user
+        if not user.is_logged_in or not user.is_active:
+            continue
         ios_tokens = user.ios_tokens
         if ios_tokens:
             apn_payload = user_notification.to_apn_payload()

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,7 +3,7 @@ import httpx
 import ipaddress
 import uuid
 import jwt
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List, Optional, Dict
 from sqlalchemy.orm import Session
 from . import models, ios, firebase
@@ -11,16 +11,12 @@ from .settings import (
     ALLOWED_NETWORKS,
     SECRET_KEY,
     JWT_ALGORITHM,
-    ACCESS_TOKEN_EXPIRE_MINUTES,
     NB_PARALLEL_PUSH,
 )
 
 
-def create_access_token(
-    username: str, expires_delta_minutes: int = ACCESS_TOKEN_EXPIRE_MINUTES
-) -> str:
+def create_access_token(username: str, expire: datetime) -> str:
     """Encode the data as JWT, including the expiration time claim"""
-    expire = datetime.utcnow() + timedelta(minutes=expires_delta_minutes)
     to_encode = {"sub": username, "exp": expire}
     encoded_jwt = jwt.encode(to_encode, str(SECRET_KEY), algorithm=JWT_ALGORITHM)
     return encoded_jwt

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     entry_points={"console_scripts": ["notify-server=app.command:cli"]},
     extras_require={"postgres": postgres_requires, "tests": tests_requires},

--- a/tests/api/test_login.py
+++ b/tests/api/test_login.py
@@ -46,6 +46,7 @@ def test_login_existing_user(client: TestClient, db, api_version, mocker, user):
         db.query(models.User).filter(models.User.username == user.username).first()
         == user
     )
+    assert not user.is_logged_in
     response = client.post(
         f"/api/{api_version}/login",
         data={"username": user.username, "password": password},
@@ -55,3 +56,4 @@ def test_login_existing_user(client: TestClient, db, api_version, mocker, user):
     assert response.json()["token_type"] == "bearer"
     token = response.json()["access_token"]
     assert utils.decode_access_token(token)["sub"] == user.username
+    assert user.is_logged_in

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -1,10 +1,13 @@
 import pytest
+from datetime import datetime, timedelta
 from fastapi.testclient import TestClient
 from app import schemas, models, utils
 
 
 def user_authorization_headers(username):
-    token = utils.create_access_token(username)
+    token = utils.create_access_token(
+        username, expire=datetime.utcnow() + timedelta(minutes=60)
+    )
     return {"Authorization": f"Bearer {token}"}
 
 
@@ -51,7 +54,9 @@ def test_read_current_user_profile_invalid_username(client: TestClient, api_vers
 
 
 def test_read_current_user_profile_expired_token(client: TestClient, user, api_version):
-    token = utils.create_access_token(user.username, expires_delta_minutes=-5)
+    token = utils.create_access_token(
+        user.username, expire=datetime.utcnow() + timedelta(minutes=-5)
+    )
     response = client.get(
         f"/api/{api_version}/users/user/profile",
         headers={"Authorization": f"Bearer {token}"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,14 +69,20 @@ def client() -> Generator:
 
 @pytest.fixture
 def user_token_headers(user):
-    token = create_access_token(user.username)
+    token = create_access_token(
+        user.username,
+        expire=datetime.datetime.utcnow() + datetime.timedelta(minutes=60),
+    )
     return {"Authorization": f"Bearer {token}"}
 
 
 @pytest.fixture
 def admin_token_headers(user_factory):
     admin = user_factory(is_admin=True)
-    token = create_access_token(admin.username)
+    token = create_access_token(
+        admin.username,
+        expire=datetime.datetime.utcnow() + datetime.timedelta(minutes=60),
+    )
     return {"Authorization": f"Bearer {token}"}
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime, timedelta
 from sqlalchemy.orm import Session
 from app import schemas
 
@@ -12,6 +13,14 @@ def test_user(db: Session, user_factory) -> None:
     assert not hasattr(user, "token")
     assert user.device_tokens == []
     assert user._device_tokens == ""
+
+
+def test_user_is_logged_in(db: Session, user_factory) -> None:
+    username = "johndoe"
+    user = user_factory(username=username)
+    assert not user.is_logged_in
+    user.login_token_expire_date = datetime.utcnow() + timedelta(minutes=5)
+    assert user.is_logged_in
 
 
 def test_user_add_device_token(db: Session, user) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime, timedelta
 from app import schemas, utils
 
 
@@ -140,7 +141,9 @@ async def test_send_notification(
 
 def test_create_and_decode_access_token():
     username = "johndoe"
-    encoded_token = utils.create_access_token(username)
+    encoded_token = utils.create_access_token(
+        username, expire=datetime.utcnow() + timedelta(days=1)
+    )
     decoded_token = utils.decode_access_token(encoded_token)
     assert decoded_token["sub"] == username
     # Token includes Expiration Time Claim


### PR DESCRIPTION
Add `login_token_expire_date` column to users table. Allow to save the login token expire date and check if a user is
currently logged in. This is updated when a new login token is created (when login via the API).

If the user isn't currently logged in (no active token), no notifications will be sent.
To avoid issue when deploying this, the migration script will set a default value to the current date + 30 days so that users will continue receiving notifications. No need to invalidate the current tokens. The date will properly be updated when users login again. This will really start working in 30 days (users who don't login again won't receive notifications anymore).

I also updated the Docker image to use Python 3.10.

I haven't added this new field to the API schema. It could be useful for debugging but I don't know if it has an impact on the client.
