### PR TITLE
Add endpoint to delete device tokens

### DIFF
--- a/app/api/users.py
+++ b/app/api/users.py
@@ -119,6 +119,24 @@ def create_current_user_device_token(
     return crud.create_user_device_token(db, device_token.device_token, current_user)
 
 
+@router.delete("/{user_id}/device-token", status_code=status.HTTP_204_NO_CONTENT)
+@version(2)
+def delete_user_device_token(
+    user_id: int,
+    device_token: schemas.DeviceToken,
+    db: Session = Depends(deps.get_db),
+    current_user: models.User = Depends(deps.get_current_admin_user),
+):
+    """Delete a user device token - admin only"""
+    user = crud.get_user(db, user_id)
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    crud.remove_user_device_token(db, user, device_token.device_token)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
 @router.get("/user/services", response_model=List[schemas.UserService])
 def read_current_user_services(
     db: Session = Depends(deps.get_db),

--- a/app/ios.py
+++ b/app/ios.py
@@ -53,6 +53,11 @@ async def send_push(
         return False
     except httpx.HTTPStatusError as exc:
         logger.warning(f"{exc}")
+        try:
+            logger.warning(f"response: {response.json()}")
+        except Exception:
+            logger.warning("No json response content")
+        # See https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
         if response.status_code == 410:
             logger.info(
                 f"Device token no longer active. Delete {apn} for user {user.username}"


### PR DESCRIPTION
- new endpoint: `/users/{user_id}/device-token` is for admin only
- log json response in case of HTTP error when sending notification to iOS

@emanuelelaface it would be good to reproduce the issue with this version. I'd like to see what is in the json response.
After you could try to delete a token from the Swagger UI.