### PR TITLE
Use timezone aware datetime objects and use local time in webapp

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/alembic/versions/43f8a46a10f4_add_login_token_expire_date.py
+++ b/alembic/versions/43f8a46a10f4_add_login_token_expire_date.py
@@ -6,7 +6,7 @@ Create Date: 2022-10-16 07:42:13.437968
 
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from alembic import op
 import sqlalchemy as sa
 
@@ -26,7 +26,7 @@ def upgrade():
     # To avoid having to reset all tokens, we set the default value to the current date + 30 days
     # when running this migration. This ensures users will continue to receive notifications with
     # their current login token.
-    expire = datetime.utcnow() + timedelta(days=30)
+    expire = datetime.now(timezone.utc) + timedelta(days=30)
     users = sa.sql.table("users", sa.sql.column("login_token_expire_date"))
     op.execute(users.update().values(login_token_expire_date=expire))
     op.alter_column("users", "login_token_expire_date", nullable=False)

--- a/app/api/login.py
+++ b/app/api/login.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.logger import logger
@@ -26,7 +26,7 @@ def login(
     if db_user is None:
         db_user = crud.create_user(db, form_data.username.lower())
         response.status_code = status.HTTP_201_CREATED
-    expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = utils.create_access_token(db_user.username, expire=expire)
     crud.update_user_login_token_expire_date(db, db_user, expire)
     return {"access_token": access_token, "token_type": "bearer"}

--- a/app/crud.py
+++ b/app/crud.py
@@ -240,7 +240,9 @@ def update_user_notifications(
 
 def delete_notifications(db: Session, keep_days: int) -> None:
     """Delete notifications older than X days"""
-    date_limit = datetime.datetime.utcnow() - datetime.timedelta(days=keep_days)
+    date_limit = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+        days=keep_days
+    )
     # First retrieve all notifications id to delete
     old_notification_ids = db.query(models.Notification.id).filter(
         models.Notification.timestamp < date_limit

--- a/app/settings.py
+++ b/app/settings.py
@@ -78,3 +78,6 @@ ESS_NOTIFY_SERVER_ENVIRONMENT = config(
 )
 
 APP_NAME = config("APP_NAME", cast=str, default="ESS Notify")
+
+# Local timezone used for timestamp in the web app
+LOCAL_TIMEZONE = config("LOCAL_TIMEZONE", cast=str, default="Europe/Stockholm")

--- a/app/templates/_helpers.html
+++ b/app/templates/_helpers.html
@@ -9,10 +9,6 @@
 </pre>
 {%- endmacro %}
 
-{% macro format_datetime(dt) -%}
-{{ dt.strftime("%Y-%m-%d %H:%M:%S") }}
-{%- endmacro %}
-
 {% macro is_checked(value, expected) -%}
 {% if value == expected %}checked{% endif -%}
 {%- endmacro %}

--- a/app/templates/notifications_table.html
+++ b/app/templates/notifications_table.html
@@ -1,4 +1,4 @@
-{% from "_helpers.html" import format_notification, format_datetime %}
+{% from "_helpers.html" import format_notification %}
 
 <table class="table table-striped table-sm" id="notifications-table">
   <thead>
@@ -12,7 +12,7 @@
     {% for notification in notifications %}
     <tr>
       <td>{{ categories[notification.service_id] }}</td>
-      <td>{{ format_datetime(notification.timestamp) }}</td>
+      <td>{{ notification.timestamp | format_datetime }}</td>
       <td>{{ format_notification(notification) }}</td>
     </tr>
     {% endfor %}

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,7 +3,7 @@ import httpx
 import ipaddress
 import uuid
 import jwt
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Dict
 from sqlalchemy.orm import Session
 from . import models, ios, firebase
@@ -75,7 +75,7 @@ async def gather_with_concurrency(n: int, *tasks, return_exceptions=True):
 async def send_notification(db: Session, notification: models.Notification) -> None:
     """Send the notification to all subscribers"""
     tasks = []
-    ios_headers = ios.create_headers(datetime.utcnow())
+    ios_headers = ios.create_headers(datetime.now(timezone.utc))
     ios_client = httpx.AsyncClient(http2=True, headers=ios_headers)
     android_headers = await firebase.create_headers(str(uuid.uuid4()))
     android_client = httpx.AsyncClient(headers=android_headers)

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -1,5 +1,14 @@
 from pathlib import Path
+from zoneinfo import ZoneInfo
 from starlette.templating import Jinja2Templates
+from ..settings import LOCAL_TIMEZONE
 
 app_dir = Path(__file__).parents[1].resolve()
 templates = Jinja2Templates(directory=str(app_dir / "templates"))
+
+
+def format_datetime(dt):
+    return dt.astimezone(ZoneInfo(LOCAL_TIMEZONE)).strftime("%Y-%m-%d %H:%M:%S")
+
+
+templates.env.filters["format_datetime"] = format_datetime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,3 @@
-[tool.black]
-target_version = ['py37']
-
 [build-system]
 requires = ["setuptools >= 42", "wheel", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,5 @@ setuptools.setup(
     ],
     entry_points={"console_scripts": ["notify-server=app.command:cli"]},
     extras_require={"postgres": postgres_requires, "tests": tests_requires},
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )

--- a/tests/api/test_services.py
+++ b/tests/api/test_services.py
@@ -5,6 +5,7 @@ import importlib.metadata
 import packaging.version
 from fastapi.testclient import TestClient
 from app import models, schemas
+from ..utils import no_tz_isoformat
 
 
 @pytest.fixture(scope="module")
@@ -155,7 +156,7 @@ def test_read_service_notifications(
             "id": notification1.id,
             "service_id": str(notification1.service_id),
             "subtitle": notification1.subtitle,
-            "timestamp": notification1.timestamp.isoformat(),
+            "timestamp": no_tz_isoformat(notification1.timestamp),
             "title": notification1.title,
             "url": notification1.url,
         },
@@ -163,7 +164,7 @@ def test_read_service_notifications(
             "id": notification2.id,
             "service_id": str(notification2.service_id),
             "subtitle": notification2.subtitle,
-            "timestamp": notification2.timestamp.isoformat(),
+            "timestamp": no_tz_isoformat(notification2.timestamp),
             "title": notification2.title,
             "url": notification2.url,
         },
@@ -262,7 +263,7 @@ def test_create_notification_for_service(
         "id": db_notification.id,
         "service_id": str(service.id),
         "subtitle": sample_notification["subtitle"],
-        "timestamp": db_notification.timestamp.isoformat(),
+        "timestamp": no_tz_isoformat(db_notification.timestamp),
         "title": sample_notification["title"],
         "url": sample_notification["url"],
     }

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -1,12 +1,13 @@
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from fastapi.testclient import TestClient
 from app import schemas, models, utils
+from ..utils import no_tz_isoformat
 
 
 def user_authorization_headers(username):
     token = utils.create_access_token(
-        username, expire=datetime.utcnow() + timedelta(minutes=60)
+        username, expire=datetime.now(timezone.utc) + timedelta(minutes=60)
     )
     return {"Authorization": f"Bearer {token}"}
 
@@ -55,7 +56,7 @@ def test_read_current_user_profile_invalid_username(client: TestClient, api_vers
 
 def test_read_current_user_profile_expired_token(client: TestClient, user, api_version):
     token = utils.create_access_token(
-        user.username, expire=datetime.utcnow() + timedelta(minutes=-5)
+        user.username, expire=datetime.now(timezone.utc) + timedelta(minutes=-5)
     )
     response = client.get(
         f"/api/{api_version}/users/user/profile",
@@ -257,7 +258,7 @@ def test_read_current_user_notifications(
             "is_read": False,
             "service_id": str(notification1.service_id),
             "subtitle": notification1.subtitle,
-            "timestamp": notification1.timestamp.isoformat(),
+            "timestamp": no_tz_isoformat(notification1.timestamp),
             "title": notification1.title,
             "url": notification1.url,
         },
@@ -266,7 +267,7 @@ def test_read_current_user_notifications(
             "is_read": False,
             "service_id": str(notification2.service_id),
             "subtitle": notification2.subtitle,
-            "timestamp": notification2.timestamp.isoformat(),
+            "timestamp": no_tz_isoformat(notification2.timestamp),
             "title": notification2.title,
             "url": notification2.url,
         },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,8 @@ def client() -> Generator:
 def user_token_headers(user):
     token = create_access_token(
         user.username,
-        expire=datetime.datetime.utcnow() + datetime.timedelta(minutes=60),
+        expire=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(minutes=60),
     )
     return {"Authorization": f"Bearer {token}"}
 
@@ -81,7 +82,8 @@ def admin_token_headers(user_factory):
     admin = user_factory(is_admin=True)
     token = create_access_token(
         admin.username,
-        expire=datetime.datetime.utcnow() + datetime.timedelta(minutes=60),
+        expire=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(minutes=60),
     )
     return {"Authorization": f"Bearer {token}"}
 
@@ -102,6 +104,8 @@ def make_device_token():
 @pytest.fixture
 def notification_date():
     def _notification_date(days_old):
-        return datetime.datetime.utcnow() - datetime.timedelta(days=days_old)
+        return datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
+            days=days_old
+        )
 
     return _notification_date

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -210,7 +210,7 @@ def test_get_user_notifications_limit(db, user, service, limit, sort):
     user.subscribe(service)
     db.commit()
     notifications = []
-    now = datetime.datetime.now()
+    now = datetime.datetime.now(datetime.timezone.utc)
     for nb in range(20):
         notification = crud.create_service_notification(
             db, schemas.NotificationCreate(title=f"message{nb}"), service
@@ -253,7 +253,7 @@ def test_get_user_notifications_filter_services_id(db, user, service_factory):
     user.subscribe(service3)
     db.commit()
     notifications = []
-    now = datetime.datetime.now()
+    now = datetime.datetime.now(datetime.timezone.utc)
     for service_nb, service in enumerate((service1, service2, service3), start=1):
         for nb in range(10):
             notification = crud.create_service_notification(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from sqlalchemy.orm import Session
 from app import schemas
 
@@ -19,7 +19,7 @@ def test_user_is_logged_in(db: Session, user_factory) -> None:
     username = "johndoe"
     user = user_factory(username=username)
     assert not user.is_logged_in
-    user.login_token_expire_date = datetime.utcnow() + timedelta(minutes=5)
+    user.login_token_expire_date = datetime.now(timezone.utc) + timedelta(minutes=5)
     assert user.is_logged_in
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from app import schemas, utils
 
 
@@ -58,7 +58,7 @@ async def test_send_notification(
     android_token3 = make_device_token(128)
     android_token4 = make_device_token(128)
     android_token5 = make_device_token(128)
-    expire_date = datetime.utcnow() + timedelta(minutes=60)
+    expire_date = datetime.now(timezone.utc) + timedelta(minutes=60)
     user1 = user_factory(
         device_tokens=[ios_token1, ios_token2], login_token_expire_date=expire_date
     )
@@ -71,7 +71,7 @@ async def test_send_notification(
     )
     user4 = user_factory(
         device_tokens=[ios_token5, android_token5],
-        login_token_expire_date=datetime.utcnow() + timedelta(minutes=-1),
+        login_token_expire_date=datetime.now(timezone.utc) + timedelta(minutes=-1),
     )
     user5 = user_factory(
         device_tokens=[ios_token5, android_token5],
@@ -167,7 +167,7 @@ async def test_send_notification(
 def test_create_and_decode_access_token():
     username = "johndoe"
     encoded_token = utils.create_access_token(
-        username, expire=datetime.utcnow() + timedelta(days=1)
+        username, expire=datetime.now(timezone.utc) + timedelta(days=1)
     )
     decoded_token = utils.decode_access_token(encoded_token)
     assert decoded_token["sub"] == username

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+import datetime
+
+
+def no_tz_isoformat(dt: datetime.datetime) -> str:
+    """Return a datetime as string without the timezone information
+
+    We were using naive datetime object previously (using utcnow()).
+    We switch to timezone aware datetime but must continue returning
+    timestamp without timezone info in json to not brake compatibility
+    with current mobile clients.
+    """
+    return dt.isoformat().replace("+00:00", "")


### PR DESCRIPTION
* `datetime.utcnow()` is deprecated in 3.12 as it returns a naive datetime.
  Use timezone aware datetime objects internally.
  Pydantic serialization adds "Z" to timestamp in UTC timezone. To not brake current mobile clients, we continue returning timestamp without timezone info. We use a custom PlainSerializer. Note that python isoformat() doesn't return "Z" but "+00:00".
* Format datetime in local timezone in web app
* Drop support for Python 3.8 (`zoneinfo` was introduced in 3.9)