### PR TITLE
Fix send_notification background task

### DIFF
--- a/app/api/services.py
+++ b/app/api/services.py
@@ -115,5 +115,5 @@ def create_notification_for_service(
         db=db, notification=notification, service=db_service
     )
     # Send notification using background task
-    background_tasks.add_task(utils.send_notification, db, db_notification)
+    background_tasks.add_task(utils.send_notification, db_notification.id)
     return db_notification

--- a/app/crud.py
+++ b/app/crud.py
@@ -180,6 +180,16 @@ def create_service_notification(
     return db_notification
 
 
+def get_notification(
+    db: Session, notification_id: int
+) -> Optional[models.Notification]:
+    return (
+        db.query(models.Notification)
+        .filter(models.Notification.id == notification_id)
+        .first()
+    )
+
+
 def get_user_notifications(
     db: Session,
     user: models.User,

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,8 +5,9 @@ import uuid
 import jwt
 from datetime import datetime, timezone
 from typing import List, Optional, Dict
-from sqlalchemy.orm import Session
-from . import models, ios, firebase
+from fastapi.logger import logger
+from .database import SessionLocal
+from . import crud, ios, firebase
 from .settings import (
     ALLOWED_NETWORKS,
     SECRET_KEY,
@@ -72,39 +73,49 @@ async def gather_with_concurrency(n: int, *tasks, return_exceptions=True):
     )
 
 
-async def send_notification(db: Session, notification: models.Notification) -> None:
+async def send_notification(notification_id: int) -> None:
     """Send the notification to all subscribers"""
     tasks = []
     ios_headers = ios.create_headers(datetime.now(timezone.utc))
     ios_client = httpx.AsyncClient(http2=True, headers=ios_headers)
     android_headers = await firebase.create_headers(str(uuid.uuid4()))
     android_client = httpx.AsyncClient(headers=android_headers)
-    for user_notification in notification.users_notification:
-        user = user_notification.user
-        if not user.is_logged_in or not user.is_active:
-            continue
-        ios_tokens = user.ios_tokens
-        if ios_tokens:
-            apn_payload = user_notification.to_apn_payload()
-            for ios_token in ios_tokens:
+    try:
+        db = SessionLocal()
+        notification = crud.get_notification(db, notification_id)
+        if notification is None:
+            logger.warning(
+                f"Can't send notification! Notification {notification_id} not found."
+            )
+            return
+        for user_notification in notification.users_notification:
+            user = user_notification.user
+            if not user.is_logged_in or not user.is_active:
+                continue
+            ios_tokens = user.ios_tokens
+            if ios_tokens:
+                apn_payload = user_notification.to_apn_payload()
+                for ios_token in ios_tokens:
+                    tasks.append(
+                        ios.send_push(
+                            ios_client,
+                            ios_token,
+                            apn_payload,
+                            db,
+                            user,
+                        )
+                    )
+            for android_token in user.android_tokens:
                 tasks.append(
-                    ios.send_push(
-                        ios_client,
-                        ios_token,
-                        apn_payload,
+                    firebase.send_push(
+                        android_client,
+                        user_notification.to_android_payload(android_token),
                         db,
                         user,
                     )
                 )
-        for android_token in user.android_tokens:
-            tasks.append(
-                firebase.send_push(
-                    android_client,
-                    user_notification.to_android_payload(android_token),
-                    db,
-                    user,
-                )
-            )
-    await gather_with_concurrency(NB_PARALLEL_PUSH, *tasks, return_exceptions=True)
-    await ios_client.aclose()
-    await android_client.aclose()
+        await gather_with_concurrency(NB_PARALLEL_PUSH, *tasks, return_exceptions=True)
+        await ios_client.aclose()
+        await android_client.aclose()
+    finally:
+        db.close()

--- a/tests/api/test_services.py
+++ b/tests/api/test_services.py
@@ -258,7 +258,7 @@ def test_create_notification_for_service(
     )
     assert response.status_code == 201
     db_notification = db.query(models.Notification).first()
-    mock_send_notification.assert_called_once_with(db, db_notification)
+    mock_send_notification.assert_called_once_with(db_notification.id)
     assert response.json() == {
         "id": db_notification.id,
         "service_id": str(service.id),


### PR DESCRIPTION
We shouldn't pass the session to the background task. get_db() dependency will close the session after the request. There is no warranty the session won't be closed before the background task is done.

Instead we create a local session in the background task.

Avoid:

```
File "/app/app/utils.py", line 82, in send_notification
    for user_notification in notification.users_notification:
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/sqlalchemy/orm/attributes.py", line 294, in __get__
    return self.impl.get(instance_state(instance), dict_)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/sqlalchemy/orm/attributes.py", line 730, in get
    value = self.callable_(state, passive)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/sqlalchemy/orm/strategies.py", line 717, in _load_for_state
    raise orm_exc.DetachedInstanceError(
sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <Notification at 0x7f1f8fb00c50> is not bound to a Session; lazy load operation of attribute 'users_notification' cannot proceed (Background on this error at: http://sqlalche.me/e/13/bhk3)
```
